### PR TITLE
Update to build with purescript 0.14.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bower_components
 node_modules
 .npm
 npm-debug.log
+.spago
 
 # cache
 .pulp-cache

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ main = launchAff_ do
 * Build Project
 
 ```bash
+$ yarn install
 $ yarn build
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
         "build": "pulp build"
     },
     "dependencies": {
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "pulp": "^13.0.0",
-        "purescript": "^0.13.2"
+        "purescript": "^0.14.4"
     }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,104 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+where `entityName` is one of the following:
+- dependencies
+- repo
+- version
+-------------------------------
+let upstream = --
+in  upstream
+  with packageName.entityName = "new value"
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with halogen.version = "master"
+  with halogen.repo = "https://example.com/path/to/git/repo.git"
+
+  with halogen-vdom.version = "v4.0.0"
+  with halogen-vdom.dependencies = [ "extra-dependency" ] # halogen-vdom.dependencies
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+where `<version>` is:
+- a tag (i.e. "v4.0.0")
+- a branch (i.e. "master")
+- commit hash (i.e. "701f3e44aafb1a6459281714858fadf2c4c2a977")
+-------------------------------
+let upstream = --
+in  upstream
+  with new-package-name =
+    { dependencies =
+       [ "dependency1"
+       , "dependency2"
+       ]
+    , repo =
+       "https://example.com/path/to/git/repo.git"
+    , version =
+        "<version>"
+    }
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ]
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+-------------------------------
+-}
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20210905/packages.dhall sha256:140f3630801f2b02d5f3a405d4872e0af317e4ef187016a6b00f97d59d6275c6
+
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,28 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+
+Need help? See the following resources:
+- Spago documentation: https://github.com/purescript/spago
+- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
+
+When creating a new Spago project, you can use
+`spago init --no-comments` or `spago init -C`
+to generate this file without the comments in this block.
+-}
+{ name = "my-project"
+, dependencies =
+  [ "aff"
+  , "console"
+  , "effect"
+  , "either"
+  , "foreign"
+  , "foreign-generic"
+  , "newtype"
+  , "prelude"
+  , "psci-support"
+  , "transformers"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -6,7 +6,7 @@ import Axios (class Axios, defaultAxios', genericAxios)
 import Axios.Types (Header(..), Method(..))
 import Axios.Config (auth, baseUrl, headers, method)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Foreign.Generic (class Decode, class Encode, defaultOptions, genericDecode, genericEncode)
 
 


### PR DESCRIPTION
Hi, I needed to add proxy support to purescript-axios.  First, I needed to port it to 0.14.4.  This pull request contains those changes.  I also added spago files so I could build and test with spago.   I don't know much about yarn & pulp, so I was not able to get it to compile with "yarn build".  I think it is still referencing older purescript sources.  I know that bower is still required for publishing packages, so I didn't disturb it.

Also, the first test case does not work.  Thanks to my proxy changes, I could use Fiddler to debug it.  It looks like something has changed on the service it is contacting so that it no longer gets the expected return value.  I figure that this is connecting correctly, so the test is more or less passing.